### PR TITLE
Add required safe attribute to api call

### DIFF
--- a/src/logic/gnosisManager.ts
+++ b/src/logic/gnosisManager.ts
@@ -151,6 +151,7 @@ const getNextNonce = async (config: GnosisConfig, safeAddress: string, fallback?
 
 const getGasEstimate = (config: GnosisConfig, safeAddress: string, txn: Transaction): Promise<GasEstimateResponse> => {
   return fetchJson<GasEstimateResponse>(`${config.safeRelayUrl}/api/v2/safes/${safeAddress}/transactions/estimate/`, "POST", {
+    safe: safeAddress,
     to: txn.to,
     value: txn.value.toNumber(),
     data: txn.data,


### PR DESCRIPTION
The user isn't prompted to sign the transaction unless this required attribute is in the data